### PR TITLE
Process pdf files for data extraction and comparison

### DIFF
--- a/src/components/PDFUploader.tsx
+++ b/src/components/PDFUploader.tsx
@@ -26,14 +26,15 @@ export const PDFUploader = ({ mode, onModeChange, onFilesChange, files, isLoadin
     }
   }, []);
 
+  const isPdfLike = (file: File) =>
+    file.type.toLowerCase().includes('pdf') || /\.pdf$/i.test(file.name);
+
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setDragActive(false);
 
-    const droppedFiles = Array.from(e.dataTransfer.files).filter(
-      file => file.type === 'application/pdf'
-    );
+    const droppedFiles = Array.from(e.dataTransfer.files).filter(isPdfLike);
 
     if (droppedFiles.length > 0) {
       const maxFiles = mode === 'single' ? 1 : 2;
@@ -42,9 +43,7 @@ export const PDFUploader = ({ mode, onModeChange, onFilesChange, files, isLoadin
   }, [mode, onFilesChange]);
 
   const handleFileInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFiles = Array.from(e.target.files || []).filter(
-      file => file.type === 'application/pdf'
-    );
+    const selectedFiles = Array.from(e.target.files || []).filter(isPdfLike);
 
     if (selectedFiles.length > 0) {
       const maxFiles = mode === 'single' ? 1 : 2;

--- a/src/services/extractionApi.ts
+++ b/src/services/extractionApi.ts
@@ -116,6 +116,7 @@ async function callOpenAIWithPDF({
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
+        "OpenAI-Beta": "assistants=v2",
       },
       body: JSON.stringify({
         model: "gpt-4o-mini", // Supports file_search + JSON output, cost-efficient

--- a/src/services/extractionApi.ts
+++ b/src/services/extractionApi.ts
@@ -119,17 +119,10 @@ async function callOpenAIWithPDF({
         "OpenAI-Beta": "assistants=v2",
       },
       body: JSON.stringify({
-        model: "gpt-4o-mini", // Supports file_search + JSON output, cost-efficient
-        input: [
-          {
-            role: "user",
-            content: [
-              { type: "input_text", text: combinedPrompt },
-            ],
-            attachments: [
-              { file_id: fileId, tools: [{ type: "file_search" }] },
-            ],
-          },
+        model: "gpt-4o-mini",
+        input: combinedPrompt,
+        attachments: [
+          { file_id: fileId, tools: [{ type: "file_search" }] },
         ],
         tools: [{ type: "file_search" }],
         response_format: { type: "json_object" },
@@ -145,7 +138,7 @@ async function callOpenAIWithPDF({
     const errorText = await res.text();
     console.log("Responses API Error Details:", errorText);
     if (/file_search|attachment|tool|responses|chat\.completions|content\s*type/i.test(errorText)) {
-      throw new Error('Processing failed: The service rejected the request format. Please update and retry.');
+      throw new Error('Processing failed: Request format was rejected by OpenAI (responses + attachments).');
     }
     if (/size|limit|exceed/i.test(errorText)) {
       throw new Error('Invalid document: File size exceeds OpenAI limits.');


### PR DESCRIPTION
Switch to OpenAI Responses API with file_search for PDF processing to fix invalid request errors.

The previous implementation attempted to attach PDF documents using the `document` type within the `chat/completions` endpoint, which is not supported for PDFs. This led to misleading errors about invalid file types. The fix correctly utilizes the `/v1/responses` endpoint with `file_search` tools, which is designed for file-attached analysis, and improves error messages and response parsing.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae670fd2-19a8-4317-b24f-1d421b449fc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae670fd2-19a8-4317-b24f-1d421b449fc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

